### PR TITLE
Filter out extra `derailed` and `shipped` transitions

### DIFF
--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -26,7 +26,8 @@ module Statesman
     # @return [String]
     def dot_body
       @graph.map do |vertex, edges|
-        edges.map do |to|
+        vertex == "derailed" ? [] :
+        edges.select { |edge| edge != "derailed" }.map do |to|
           "#{vertex} -> #{to};"
         end
       end.flatten

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -35,11 +35,15 @@ module Statesman
       @graph.map do |vertex, edges|
         (@happy && vertex == @vertex_to_remove) ? [] :
         edges.select { |edge|
-          !@happy || (edge != @vertex_to_remove and (edge != "shipped" or ["packed", "proteins_packed"].include?(vertex)))
+          keep_edge?(vertex, edge)
         }.map do |to|
           "#{vertex} -> #{to};"
         end
       end.flatten
+    end
+
+    def keep_edge?(vertex, edge)
+      !@happy || (edge != @vertex_to_remove and (edge != "shipped" or ["packed", "proteins_packed"].include?(vertex)))
     end
 
     def build_svg(file_name)

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -33,13 +33,16 @@ module Statesman
     # @return [String]
     def dot_body
       @graph.map do |vertex, edges|
-        (@filtered && vertex == @vertex_to_remove) ? [] :
-        edges.select { |edge|
-          keep_edge?(vertex, edge)
-        }.map do |to|
+        get_vertex_edges(vertex, edges).map do |to|
           "#{vertex} -> #{to};"
         end
       end.flatten
+    end
+
+    def get_vertex_edges(vertex, edges)
+      return [] if @filtered && vertex == @vertex_to_remove
+
+      edges.select{ |edge| keep_edge?(vertex, edge ) }
     end
 
     def keep_edge?(vertex, edge)

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -28,7 +28,9 @@ module Statesman
       vertex_to_remove = "derailed"
       @graph.map do |vertex, edges|
         vertex == vertex_to_remove ? [] :
-        edges.select { |edge| edge != vertex_to_remove }.map do |to|
+        edges.select { |edge|
+          edge != vertex_to_remove and !(edge == "shipped" && (not ["packed", "proteins_packed"].include?(vertex)))
+        }.map do |to|
           "#{vertex} -> #{to};"
         end
       end.flatten

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -24,13 +24,12 @@ module Statesman
     private
 
     # @return [String]
-    def dot_body
+    def dot_body(without_vertex = 'derailed')
       @graph.map do |vertex, edges|
-        vertex == "derailed" ? [] :
-        edges.select { |edge| edge != "derailed" }.map do |to|
+        edges.map do |to|
           "#{vertex} -> #{to};"
         end
-      end.flatten
+      end.flatten.select { |line| not line.include? without_vertex }
     end
 
     def build_svg(file_name)

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -24,12 +24,13 @@ module Statesman
     private
 
     # @return [String]
-    def dot_body(without_vertex = 'derailed')
+    def dot_body
       @graph.map do |vertex, edges|
-        edges.map do |to|
+        vertex == "derailed" ? [] :
+        edges.select { |edge| edge != "derailed" }.map do |to|
           "#{vertex} -> #{to};"
         end
-      end.flatten.select { |line| not line.include? without_vertex }
+      end.flatten
     end
 
     def build_svg(file_name)

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -25,9 +25,10 @@ module Statesman
 
     # @return [String]
     def dot_body
+      vertex_to_remove = "derailed"
       @graph.map do |vertex, edges|
-        vertex == "derailed" ? [] :
-        edges.select { |edge| edge != "derailed" }.map do |to|
+        vertex == vertex_to_remove ? [] :
+        edges.select { |edge| edge != vertex_to_remove }.map do |to|
           "#{vertex} -> #{to};"
         end
       end.flatten

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -16,9 +16,13 @@ module Statesman
 
     def to_svg(file_name = nil)
       file_name ||= @name
-      file_name += '.svg'
 
-      build_svg(file_name)
+      @happy = false
+      build_svg(file_name + '.svg')
+
+      @happy = true
+      file_name += '_happy'
+      build_svg(file_name + '.svg')
     end
 
     private
@@ -27,9 +31,9 @@ module Statesman
     def dot_body
       vertex_to_remove = "derailed"
       @graph.map do |vertex, edges|
-        vertex == vertex_to_remove ? [] :
+        (@happy && vertex == vertex_to_remove) ? [] :
         edges.select { |edge|
-          edge != vertex_to_remove and (edge != "shipped" or ["packed", "proteins_packed"].include?(vertex))
+          !@happy || (edge != vertex_to_remove and (edge != "shipped" or ["packed", "proteins_packed"].include?(vertex)))
         }.map do |to|
           "#{vertex} -> #{to};"
         end

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -18,13 +18,13 @@ module Statesman
     def to_svg(file_name = nil)
       file_name ||= @name
 
-      @happy = false
+      @filtered = false
       build_svg(file_name + '.svg')
 
       return unless @graph.key?(@vertex_to_remove)
 
-      @happy = true
-      file_name += '_happy'
+      @filtered = true
+      file_name += '_filtered'
       build_svg(file_name + '.svg')
     end
 
@@ -33,7 +33,7 @@ module Statesman
     # @return [String]
     def dot_body
       @graph.map do |vertex, edges|
-        (@happy && vertex == @vertex_to_remove) ? [] :
+        (@filtered && vertex == @vertex_to_remove) ? [] :
         edges.select { |edge|
           keep_edge?(vertex, edge)
         }.map do |to|
@@ -43,7 +43,7 @@ module Statesman
     end
 
     def keep_edge?(vertex, edge)
-      return true if not @happy
+      return true if not @filtered
       return false if edge == @vertex_to_remove
       return true if edge != "shipped"
 

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -7,6 +7,7 @@ module Statesman
     def initialize(name:, graph:)
       @name  = name
       @graph = graph
+      @vertex_to_remove = "derailed"
     end
 
     # @return [String] diagram in DOT format.
@@ -20,6 +21,8 @@ module Statesman
       @happy = false
       build_svg(file_name + '.svg')
 
+      return unless @graph.key?(@vertex_to_remove)
+
       @happy = true
       file_name += '_happy'
       build_svg(file_name + '.svg')
@@ -29,11 +32,10 @@ module Statesman
 
     # @return [String]
     def dot_body
-      vertex_to_remove = "derailed"
       @graph.map do |vertex, edges|
-        (@happy && vertex == vertex_to_remove) ? [] :
+        (@happy && vertex == @vertex_to_remove) ? [] :
         edges.select { |edge|
-          !@happy || (edge != vertex_to_remove and (edge != "shipped" or ["packed", "proteins_packed"].include?(vertex)))
+          !@happy || (edge != @vertex_to_remove and (edge != "shipped" or ["packed", "proteins_packed"].include?(vertex)))
         }.map do |to|
           "#{vertex} -> #{to};"
         end

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -29,7 +29,7 @@ module Statesman
       @graph.map do |vertex, edges|
         vertex == vertex_to_remove ? [] :
         edges.select { |edge|
-          edge != vertex_to_remove and !(edge == "shipped" && (not ["packed", "proteins_packed"].include?(vertex)))
+          edge != vertex_to_remove and (edge != "shipped" or ["packed", "proteins_packed"].include?(vertex))
         }.map do |to|
           "#{vertex} -> #{to};"
         end

--- a/lib/statesman/diagram.rb
+++ b/lib/statesman/diagram.rb
@@ -43,7 +43,11 @@ module Statesman
     end
 
     def keep_edge?(vertex, edge)
-      !@happy || (edge != @vertex_to_remove and (edge != "shipped" or ["packed", "proteins_packed"].include?(vertex)))
+      return true if not @happy
+      return false if edge == @vertex_to_remove
+      return true if edge != "shipped"
+
+      ["packed", "proteins_packed"].include?(vertex)
     end
 
     def build_svg(file_name)


### PR DESCRIPTION
See https://careof.slack.com/archives/C1ZLL965N/p1555085405019400?thread_ts=1555085323.018700&cid=C1ZLL965N

If your `wms` checkout is beside your `statesman-diagram` checkout, you can check out this branch, then go over to `wms`, make this change:

```diff
diff --git a/Gemfile b/Gemfile
index 56fe1966..4ca1871a 100644
--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,7 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'statesman-diagram', git: 'https://github.com/careofvitamins/statesman-diagram.git'
+  gem 'statesman-diagram', :path => '../statesman-diagram'

   # linting
   gem 'overcommit', require: false
```

and run this to see how the diagram comes out:

```
bundle && bundle exec rake statesman:diagram[Order::StateMachine] && open Order_StateMachine*.svg
```